### PR TITLE
Add flag for toggling daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following instructions show how to setup the environment to run this code wi
 
 ## How to use
 
-> the tool runs indefinitely until the process is killed
+> the tool runs indefinitely until the process is killed. This can be dissabled by setting the `DAEMON` option to `false`.
 
 - <a name="setup"></a>Setup the following data:
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,12 @@ func main() {
 		}
 	}()
 
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		logrus.Fatalf("AWS config could not be created: %v", err)
+	}
+
+	run(ctx, cfg)
   if viper.GetBool("DAEMON") {
     go func() {
       mux := http.NewServeMux()
@@ -71,16 +77,7 @@ func main() {
 
       http.ListenAndServe("0.0.0.0:8701", mux)
     }()
-  }
 
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		logrus.Fatalf("AWS config could not be created: %v", err)
-	}
-
-	run(ctx, cfg)
-
-  if viper.GetBool("DAEMON") {
     for range time.NewTicker(time.Hour * 10).C {
       run(ctx, cfg)
     }

--- a/main.go
+++ b/main.go
@@ -70,18 +70,18 @@ func main() {
 	}
 
 	run(ctx, cfg)
-  if viper.GetBool("DAEMON") {
-    go func() {
-      mux := http.NewServeMux()
-      mux.Handle("/metrics", promhttp.Handler())
+	if viper.GetBool("DAEMON") {
+		go func() {
+			mux := http.NewServeMux()
+			mux.Handle("/metrics", promhttp.Handler())
 
-      http.ListenAndServe("0.0.0.0:8701", mux)
-    }()
+			http.ListenAndServe("0.0.0.0:8701", mux)
+		}()
 
-    for range time.NewTicker(time.Hour * 10).C {
-      run(ctx, cfg)
-    }
-  }
+		for range time.NewTicker(time.Hour * 10).C {
+			run(ctx, cfg)
+		}
+	}
 }
 
 func run(ctx context.Context, cfg aws.Config) {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func setupViper() {
 		tokenDuration           = flag.String("CODEARTIFACT_DURATION", os.Getenv("CODEARTIFACT_DURATION"), "duration of the AWS CodeArtifact authToken")
 		codeartifactDomain      = flag.String("CODEARTIFACT_DOMAIN", os.Getenv("CODEARTIFACT_DOMAIN"), "AWS CodeArtifact Domain for which access is required")
 		codeartifactDomainOwner = flag.String("CODEARTIFACT_DOMAIN_OWNER", os.Getenv("CODEARTIFACT_DOMAIN_OWNER"), "owner (AWS acc) for the AWS CodeArtifact domain")
+		daemon                  = flag.Bool("DAEMON", true, "whether to run in Daemon mode, re-authenticating every 10 hours.")
 	)
 
 	flag.Parse()
@@ -39,6 +40,7 @@ func setupViper() {
 	viper.Set("CODEARTIFACT_DURATION", tokenDuration)
 	viper.Set("CODEARTIFACT_DOMAIN", codeartifactDomain)
 	viper.Set("CODEARTIFACT_DOMAIN_OWNER", codeartifactDomainOwner)
+	viper.Set("DAEMON", daemon)
 }
 
 func main() {
@@ -62,12 +64,14 @@ func main() {
 		}
 	}()
 
-	go func() {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
+  if viper.GetBool("DAEMON") {
+    go func() {
+      mux := http.NewServeMux()
+      mux.Handle("/metrics", promhttp.Handler())
 
-		http.ListenAndServe("0.0.0.0:8701", mux)
-	}()
+      http.ListenAndServe("0.0.0.0:8701", mux)
+    }()
+  }
 
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -76,9 +80,11 @@ func main() {
 
 	run(ctx, cfg)
 
-	for range time.NewTicker(time.Hour * 10).C {
-		run(ctx, cfg)
-	}
+  if viper.GetBool("DAEMON") {
+    for range time.NewTicker(time.Hour * 10).C {
+      run(ctx, cfg)
+    }
+  }
 }
 
 func run(ctx context.Context, cfg aws.Config) {
@@ -111,6 +117,7 @@ func getCodeArtifactSecret(ctx context.Context, cfg aws.Config) (*string, error)
 		Domain:          &domain,
 		DomainOwner:     &domainOwner,
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("retrieving code artifact secret: %w", err)
 	}


### PR DESCRIPTION
We added this feature for our own use and thought we would send it upstream incase it is useful to other.

The `DAEMON` configuration option toggles whether to start a run loop or execute `run()` once and exit.
`DAEMON` will default to true persisting current behaviour.

This allows the tool to be run "once-off" such as in CRON jobs or build pipelines.